### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 data/gsod_????.tar
 data/ish-history.csv
 data/ish-inventory.csv.z
+data/isd-history.csv
+data/isd-inventory.csv.z
 bin
 pkg
 work

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ DATA=data/isd-history.csv \
 	data/gsod_2010.tar \
 	data/gsod_2011.tar \
 	data/gsod_2012.tar \
-	data/gsod_2013.tar
+	data/gsod_2013.tar \
+	data/gsod_2014.tar \
+	data/gsod_2015.tar \
+	data/gsod_2016.tar \
+	data/gsod_2017.tar
 
 ALL : work/norm.json
 
@@ -40,11 +44,11 @@ bin/serve: src/cmds/serve.go src/github.com/kellegous/pork
 
 data/isd-history.csv: bin/download
 	@echo 'DOWNLOADING GSOD DATA'
-	@./bin/download 1990-2013
+	@./bin/download 1990-2017
 
 data/gsod_%.tar : bin/download
 	@echo 'DOWNLOADING GSOD DATA'
-	@./bin/download 1990-2013
+	@./bin/download 1990-2017
 
 work/zips.json: bin/build-zips
 	@echo 'BUILDING ZIP DATA'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DATA=data/ish-history.csv \
+DATA=data/isd-history.csv \
 	data/gsod_1990.tar \
 	data/gsod_1991.tar \
 	data/gsod_1992.tar \
@@ -38,7 +38,7 @@ bin/build-grid: work/zips.json
 bin/serve: src/cmds/serve.go src/github.com/kellegous/pork
 	@GOPATH=`pwd` go build -o $@ src/cmds/serve.go
 
-data/ish-history.csv: bin/download
+data/isd-history.csv: bin/download
 	@echo 'DOWNLOADING GSOD DATA'
 	@./bin/download 1990-2013
 

--- a/src/cmds/download.go
+++ b/src/cmds/download.go
@@ -94,8 +94,8 @@ func main() {
   os.MkdirAll(*flagDest, os.ModePerm)
 
   if err := EnsureDownloadAll(*flagDest,
-    "ftp://ftp.ncdc.noaa.gov/pub/data/noaa/ish-history.csv",
-    "ftp://ftp.ncdc.noaa.gov/pub/data/noaa/ish-inventory.csv.z"); err != nil {
+    "ftp://ftp.ncdc.noaa.gov/pub/data/noaa/isd-history.csv",
+    "ftp://ftp.ncdc.noaa.gov/pub/data/noaa/isd-inventory.csv.z"); err != nil {
     panic(err)
   }
 

--- a/src/coriolis/coriolis.go
+++ b/src/coriolis/coriolis.go
@@ -129,7 +129,7 @@ func stationInUsBounds(s *Station) bool {
     return false
   }
 
-  if s.Lon > -60 || s.Lon < -130 {
+  if s.Lon > -60 || s.Lon < -125 {
     return false
   }
 

--- a/src/coriolis/coriolis.go
+++ b/src/coriolis/coriolis.go
@@ -10,7 +10,7 @@ import (
   "strings"
 )
 
-const HistoryFile = "ish-history.csv"
+const HistoryFile = "isd-history.csv"
 
 type Station struct {
   Usaf     string
@@ -59,7 +59,7 @@ func parseLatLon(s string, v *float64) error {
     return nil
   }
 
-  n, err := strconv.ParseInt(s[1:], 10, 64)
+  n, err := strconv.ParseFloat(s[1:], 64)
   if err != nil {
     return err
   }
@@ -68,7 +68,7 @@ func parseLatLon(s string, v *float64) error {
     n = -n
   }
 
-  *v = float64(n) / 1000
+  *v = float64(n)
   return nil
 }
 
@@ -99,14 +99,14 @@ func ForEachStation(dir string, fn func(s *Station) error) error {
     s.Wban = v[1]
     s.Name = v[2]
     s.Country = v[3]
-    s.State = v[5]
-    s.Call = v[6]
+    s.State = v[4]
+    s.Call = v[5]
 
-    if err := parseLatLon(v[7], &s.Lat); err != nil {
+    if err := parseLatLon(v[6], &s.Lat); err != nil {
       return err
     }
 
-    if err := parseLatLon(v[8], &s.Lon); err != nil {
+    if err := parseLatLon(v[7], &s.Lon); err != nil {
       return err
     }
 


### PR DESCRIPTION
fixes #1 

1. The issue is happening because `ish` is deprecated for `isd`. There were some slight changes in the data format, including `lat/lon` being sent with decimals.
2. When run, the projection included many stations around Lon=-130, which is offshore of mainland US. Because of `computeTransform`'s projection, these stations were mapped to the edge of the map (instead of places like San Francisco). This was fixed by removing those offshore stations.
3. I added 2014-2017 data in the computation.

